### PR TITLE
add tpcch and skeleton benchmark

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -6,3 +6,4 @@ from user import User
 
 from bench_skeleton import SkeletonBenchmark, SkeletonUser
 from bench_tpcc import TPCCBenchmark, TPCCUser
+from bench_tpcch import TPCCHBenchmark, TPCCHUser

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,6 +1,7 @@
 from benchmark import Benchmark
 from build import Build
 from plotter import Plotter
+from tpcch_plotter import TPCCHPlotter
 from settings import Settings
 from user import User
 

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -4,4 +4,5 @@ from plotter import Plotter
 from settings import Settings
 from user import User
 
+from bench_skeleton import SkeletonBenchmark, SkeletonUser
 from bench_tpcc import TPCCBenchmark, TPCCUser

--- a/benchmark/bench_skeleton.py
+++ b/benchmark/bench_skeleton.py
@@ -1,0 +1,61 @@
+
+import httplib
+import logging
+import os
+import requests
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+from benchmark import Benchmark
+from user import User
+
+class SkeletonUser(User):
+
+    def __init__(self, userId, host, port, dirOutput, queryDict, **kwargs):
+        User.__init__(self, userId, host, port, dirOutput, queryDict, **kwargs)
+
+        self.perf = {}
+        self.numErrors = 0
+
+    def prepareUser(self):
+        """ executed once when user starts """
+        self.userStartTime = time.time()
+
+    def runUser(self):
+        """ main user activity """
+        self.perf = {}
+        tStart = time.time()
+        
+        # do something here...
+
+        self.numErrors = 0
+        tEnd = time.time()
+        self.log("runs", [tEnd-tStart, tStart-self.userStartTime, self.numErrors])
+
+    def stopUser(self):
+        """ executed once after stop request was sent to user """
+        pass
+
+    def formatLog(self, key, value):
+        if key == "runs":
+            logStr = "%f;%f;%i" % (value[0], value[1], value[2])
+            return logStr
+        elif key == "failed":
+            return "%f;%f;%i\n" % (value[0], value[1], value[2])
+        else:
+            return "%s\n" % str(value)
+
+
+class SkeletonBenchmark(Benchmark):
+
+    def __init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs):
+        Benchmark.__init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs)
+
+        self.setUserClass(SkeletonUser)
+
+    def benchPrepare(self):
+        pass
+

--- a/benchmark/bench_skeleton.py
+++ b/benchmark/bench_skeleton.py
@@ -24,24 +24,28 @@ class SkeletonUser(User):
         """ executed once when user starts """
         self.userStartTime = time.time()
 
+        self.queryString = open("hyrise/test/gettingstarted.json").read()
+
     def runUser(self):
         """ main user activity """
         self.perf = {}
         tStart = time.time()
         
-        # do something here...
+        result = self.fireQuery(self.queryString)
+
+        #print result.text
 
         self.numErrors = 0
         tEnd = time.time()
-        self.log("runs", [tEnd-tStart, tStart-self.userStartTime, self.numErrors])
+        self.log("succeeded", [tEnd-tStart, tStart-self.userStartTime])
 
     def stopUser(self):
         """ executed once after stop request was sent to user """
         pass
 
     def formatLog(self, key, value):
-        if key == "runs":
-            logStr = "%f;%f;%i" % (value[0], value[1], value[2])
+        if key == "succeeded":
+            logStr = "%f;%f\n" % (value[0], value[1])
             return logStr
         elif key == "failed":
             return "%f;%f;%i\n" % (value[0], value[1], value[2])
@@ -55,6 +59,9 @@ class SkeletonBenchmark(Benchmark):
         Benchmark.__init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs)
 
         self.setUserClass(SkeletonUser)
+
+        self._dirHyriseDB = os.path.join(os.getcwd(), "hyrise/test")
+        os.environ['HYRISE_DB_PATH'] = self._dirHyriseDB
 
     def benchPrepare(self):
         pass

--- a/benchmark/bench_tpcch.py
+++ b/benchmark/bench_tpcch.py
@@ -27,14 +27,14 @@ class TPCCHUser(User):
     def runUser(self):
         """ main user activity """
         self.perf = {}
-        tStart = time.time()
 
         for id in self._queryDict.keys():
+            tStart = time.time()
             self.fireQueryId(id)
+            tEnd = time.time()
+            self.log("succeeded", [id, tEnd-tStart, tStart-self.userStartTime])
 
         self.numErrors = 0
-        tEnd = time.time()
-        self.log("succeeded", [tEnd-tStart, tStart-self.userStartTime])
 
     def stopUser(self):
         """ executed once after stop request was sent to user """
@@ -45,17 +45,17 @@ class TPCCHUser(User):
 
     def formatLog(self, key, value):
         if key == "succeeded":
-            logStr = "%f;%f\n" % (value[0], value[1])
+            logStr = "id:%i;%f;%f\n" % (value[0], value[1], value[2])
             return logStr
         elif key == "failed":
-            return "%f;%f;%i\n" % (value[0], value[1], value[2])
+            return "id:%i;%f;%f\n" % (value[0], value[1], value[2])
         else:
             return "%s\n" % str(value)
 
 
 class TPCCHBenchmark(Benchmark):
 
-    def __init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs):
+    def __init__(self, queryIds, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs):
         Benchmark.__init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs)
 
         self.setUserClass(TPCCHUser)
@@ -63,13 +63,9 @@ class TPCCHBenchmark(Benchmark):
         self._dirHyriseDB = os.path.join(os.getcwd(), "hyrise/test")
         os.environ['HYRISE_DB_PATH'] = self._dirHyriseDB
 
+        for id in queryIds:
+            self.addQueryFile(id, "hyrise/test/tpcch/query%s.json" % id)
+
     def benchPrepare(self):
         tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_tables.json").read()
-        self.addQueryFile(1, "hyrise/test/tpcch/query1.json")
-        self.addQueryFile(3, "hyrise/test/tpcch/query1.json")
-        self.addQueryFile(6, "hyrise/test/tpcch/query1.json")
-        self.addQueryFile(18, "hyrise/test/tpcch/query1.json")
-        self.addQueryFile(19, "hyrise/test/tpcch/query1.json")
-
         self.fireQuery(tpccTableLoad)
-

--- a/benchmark/bench_tpcch.py
+++ b/benchmark/bench_tpcch.py
@@ -72,8 +72,12 @@ class TPCCHBenchmark(Benchmark):
         for id in queryIds:
             self.addQueryFile(id, queryBaseName % id)
 
-
     def benchPrepare(self):
-        if not self.useMysqlTables:
-            tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_tables.json").read()
+        if self.useMysqlTables:
+            tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_mysql_tables.json").read()
+            print "loading tables from mysql host..."
+            self.fireQuery(tpccTableLoad)
+            print " ...done"
+        else:
+            tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_csv_tables.json").read()
             self.fireQuery(tpccTableLoad)

--- a/benchmark/bench_tpcch.py
+++ b/benchmark/bench_tpcch.py
@@ -33,6 +33,7 @@ class TPCCHUser(User):
             self.fireQueryId(id)
             tEnd = time.time()
             self.log("succeeded", [id, tEnd-tStart, tStart-self.userStartTime])
+            print "query done: " + str(id)
 
         self.numErrors = 0
 
@@ -55,7 +56,7 @@ class TPCCHUser(User):
 
 class TPCCHBenchmark(Benchmark):
 
-    def __init__(self, queryIds, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs):
+    def __init__(self, queryIds, benchmarkGroupId, benchmarkRunId, buildSettings, useMysqlTables=False, **kwargs):
         Benchmark.__init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs)
 
         self.setUserClass(TPCCHUser)
@@ -63,9 +64,18 @@ class TPCCHBenchmark(Benchmark):
         self._dirHyriseDB = os.path.join(os.getcwd(), "hyrise/test")
         os.environ['HYRISE_DB_PATH'] = self._dirHyriseDB
 
+        self.useMysqlTables = useMysqlTables
+        queryBaseName = ""
+        if useMysqlTables:
+            queryBaseName = "hyrise/test/tpcch/mysqlQuery%s.json"
+        else:
+            queryBaseName = "hyrise/test/tpcch/query%s.json"
+
         for id in queryIds:
-            self.addQueryFile(id, "hyrise/test/tpcch/query%s.json" % id)
+            self.addQueryFile(id, queryBaseName % id)
+
 
     def benchPrepare(self):
-        tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_tables.json").read()
-        self.fireQuery(tpccTableLoad)
+        if not self.useMysqlTables:
+            tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_tables.json").read()
+            self.fireQuery(tpccTableLoad)

--- a/benchmark/bench_tpcch.py
+++ b/benchmark/bench_tpcch.py
@@ -32,8 +32,7 @@ class TPCCHUser(User):
             tStart = time.time()
             self.fireQueryId(id)
             tEnd = time.time()
-            self.log("succeeded", [id, tEnd-tStart, tStart-self.userStartTime])
-            print "query done: " + str(id)
+            self.log("queries", [id, tEnd-tStart, tStart-self.userStartTime])
 
         self.numErrors = 0
 
@@ -45,12 +44,11 @@ class TPCCHUser(User):
         self.fireQuery(self._queryDict[queryId], queryArgs, sessionContext, autocommit, stored_procedure)
 
     def formatLog(self, key, value):
-        if key == "succeeded":
-            logStr = "id:%i;%f;%f\n" % (value[0], value[1], value[2])
+        if key == "queries":  # log: id, duration, start time
+            logStr = "%i;%f;%f\n" % (value[0], value[1], value[2])
             return logStr
-        elif key == "failed":
-            return "id:%i;%f;%f\n" % (value[0], value[1], value[2])
         else:
+            print "invalid key for log event: %s" % key
             return "%s\n" % str(value)
 
 

--- a/benchmark/bench_tpcch.py
+++ b/benchmark/bench_tpcch.py
@@ -1,0 +1,75 @@
+
+import httplib
+import logging
+import os
+import requests
+import shutil
+import signal
+import subprocess
+import sys
+import time
+
+from benchmark import Benchmark
+from user import User
+
+class TPCCHUser(User):
+
+    def __init__(self, userId, host, port, dirOutput, queryDict, **kwargs):
+        User.__init__(self, userId, host, port, dirOutput, queryDict, **kwargs)
+
+        self.perf = {}
+        self.numErrors = 0
+
+    def prepareUser(self):
+        """ executed once when user starts """
+        self.userStartTime = time.time()
+
+    def runUser(self):
+        """ main user activity """
+        self.perf = {}
+        tStart = time.time()
+
+        for id in self._queryDict.keys():
+            self.fireQueryId(id)
+
+        self.numErrors = 0
+        tEnd = time.time()
+        self.log("succeeded", [tEnd-tStart, tStart-self.userStartTime])
+
+    def stopUser(self):
+        """ executed once after stop request was sent to user """
+        pass
+
+    def fireQueryId(self, queryId, queryArgs={"papi": "NO_PAPI"}, sessionContext=None, autocommit=False, stored_procedure=None):
+        self.fireQuery(self._queryDict[queryId], queryArgs, sessionContext, autocommit, stored_procedure)
+
+    def formatLog(self, key, value):
+        if key == "succeeded":
+            logStr = "%f;%f\n" % (value[0], value[1])
+            return logStr
+        elif key == "failed":
+            return "%f;%f;%i\n" % (value[0], value[1], value[2])
+        else:
+            return "%s\n" % str(value)
+
+
+class TPCCHBenchmark(Benchmark):
+
+    def __init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs):
+        Benchmark.__init__(self, benchmarkGroupId, benchmarkRunId, buildSettings, **kwargs)
+
+        self.setUserClass(TPCCHUser)
+
+        self._dirHyriseDB = os.path.join(os.getcwd(), "hyrise/test")
+        os.environ['HYRISE_DB_PATH'] = self._dirHyriseDB
+
+    def benchPrepare(self):
+        tpccTableLoad = open("hyrise/test/tpcc/load_tpcc_tables.json").read()
+        self.addQueryFile(1, "hyrise/test/tpcch/query1.json")
+        self.addQueryFile(3, "hyrise/test/tpcch/query1.json")
+        self.addQueryFile(6, "hyrise/test/tpcch/query1.json")
+        self.addQueryFile(18, "hyrise/test/tpcch/query1.json")
+        self.addQueryFile(19, "hyrise/test/tpcch/query1.json")
+
+        self.fireQuery(tpccTableLoad)
+

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -61,7 +61,7 @@ class Benchmark:
         self._scheduler         = kwargs["scheduler"] if kwargs.has_key("scheduler") else "CoreBoundQueuesScheduler"
         self._serverIP          = kwargs["serverIP"] if kwargs.has_key("serverIP") else "127.0.0.1"
         self._remoteUser        = kwargs["remoteUser"] if kwargs.has_key("remoteUser") else "hyrise"
-        self._remotePath        = kwargs["remotePath"] if kwargs.has_key("remotePath") else "/home/" + kwargs["remoteUser"] + "/benchmark"
+        self._remotePath        = kwargs["remotePath"] if kwargs.has_key("remotePath") else "/home/" + self._remoteUser + "/benchmark"
         if self._remote:
             self._ssh               = paramiko.SSHClient()
         else:

--- a/benchmark/plotter.py
+++ b/benchmark/plotter.py
@@ -63,6 +63,8 @@ class Plotter:
         plt.title("Total Transaction Throughput")
         plt.ylabel("Transactions per Second")
         plt.xlabel("Number of Parallel Users")
+        plotX = []
+        plotY = []
         for buildId in self._buildIds:
             plotX = []
             plotY = []
@@ -89,6 +91,8 @@ class Plotter:
         plt.title("Total Failed Transactions")
         plt.ylabel("Failed Transactions per Second")
         plt.xlabel("Number of Parallel Users")
+        plotX = []
+        plotY = []
         for buildId in self._buildIds:
             plotX = []
             plotY = []

--- a/benchmark/tpcch_plotter.py
+++ b/benchmark/tpcch_plotter.py
@@ -1,0 +1,155 @@
+import os
+from pylab import *
+
+
+# const factor to convert result times from logs
+# if papi is deactivated, logs contain time in secons
+# we want ms, so factor ist 1000
+z = 1000
+
+class TPCCHPlotter:
+
+    def __init__(self, benchmarkGroupId):
+        self._groupId = benchmarkGroupId
+        self._dirOutput = os.path.join(os.getcwd(), "plots", str(self._groupId))
+        self._varyingParameter = None
+        self._runs = self._collect()
+        self._buildIds = self._runs[self._runs.keys()[0]].keys()
+
+        if not os.path.isdir(self._dirOutput):
+            os.makedirs(self._dirOutput)
+
+    def tick(self):
+        sys.stdout.write('.')
+        sys.stdout.flush()
+
+    def printStatistics(self):
+        for runId, runData in self._runs.iteritems():
+            numUsers = runData[runData.keys()[0]]["numUsers"]
+            print "Run ID: %s [%s users]" % (runId, numUsers)
+            print "=============================="
+            for buildId, buildData in runData.iteritems():
+                if buildData == {'numUsers': 0, 'queryStats': {}}:
+                    continue
+                print "|\n+-- Build ID: %s" % buildId
+                print "|"
+                totalRuns = 0.0
+                totalTime = 0.0
+                for queryID, queryData in buildData["queryStats"].iteritems():
+                    totalRuns += queryData["totalRuns"]
+                    totalTime += queryData["userTime"]
+                for queryID, queryData in buildData["queryStats"].iteritems():
+                    print "|     -------------------------------------------------------------------------------------------"
+                    print "|     Query: {:2s} queries/s: {:05.2f}, min: {:05.2f}ms, max: {:05.2f}ms, avg: {:05.2f}ms, med: {:05.2f}ms".format(queryID, float(queryData["totalRuns"])*z / totalTime, queryData["rtMin"], queryData["rtMax"], queryData["rtAvg"], queryData["rtMed"])
+                print "|     -------------------------------------------------------------------------------------------"
+                print "|     total:            %1.2f queries/s\n" % (totalRuns*z / totalTime)
+                print "totalRuns: %i, totalTime: %1.2fs" % (totalRuns, totalTime / z)
+
+    def _collect(self):
+        runs = {}
+        dirResults = os.path.join(os.getcwd(), "results", self._groupId)
+        if not os.path.isdir(dirResults):
+            raise Exception("Group result directory '%s' not found!" % dirResults)
+
+        # --- Runs --- #
+        for run in os.listdir(dirResults):
+            dirRun = os.path.join(dirResults, run)
+            if os.path.isdir(dirRun):
+                self._collectRun(runs, run, dirRun)
+
+        return runs
+
+    def _collectRun(self, runs, currentRun, dirRun):
+        runs[currentRun] = {}
+
+        # --- Builds --- #
+        for build in os.listdir(dirRun):
+            self.tick()
+            dirBuild = os.path.join(dirRun, build)
+            if os.path.isdir(dirBuild):
+                self._collectBuild(runs, currentRun, build, dirBuild)
+
+    def _collectBuild(self, runs, run, build, dirBuild):
+        # -- Count Users --- #
+        numUsers = 0
+        for user in os.listdir(dirBuild):
+            dirUser = os.path.join(dirBuild, user)
+            if os.path.isdir(dirUser):
+                numUsers += 1
+
+        queryStats = {}
+        opStats = {}
+        hasOpData = False
+
+        # -- Users --- #
+        for user in os.listdir(dirBuild):
+            dirUser = os.path.join(dirBuild, user)
+            if os.path.isdir(dirUser):
+                self._collectUser(user, dirUser, numUsers, opStats, queryStats)
+
+        for queryId, queryData in queryStats.iteritems():
+            allRuntimes = [a[1] for a in queryData["rtTuples"]]
+            queryStats[queryId]["rtTuples"].sort(key=lambda a: a[0])
+            queryStats[queryId]["rtRaw"] = allRuntimes
+            queryStats[queryId]["rtMin"] = amin(allRuntimes)
+            queryStats[queryId]["rtMax"] = amax(allRuntimes)
+            queryStats[queryId]["rtAvg"] = average(allRuntimes)
+            queryStats[queryId]["rtMed"] = median(allRuntimes)
+            queryStats[queryId]["rtStd"] = std(allRuntimes)
+            for opId, opData in opStats[queryId].iteritems():
+                opStats[queryId][opId]["avgRuns"] = average([a[0] for a in opData["rtTuples"]])
+                opStats[queryId][opId]["rtMin"] = amin([a[1] for a in opData["rtTuples"]])
+                opStats[queryId][opId]["rtMax"] = amax([a[1] for a in opData["rtTuples"]])
+                opStats[queryId][opId]["rtAvg"] = average([a[1] for a in opData["rtTuples"]])
+                opStats[queryId][opId]["rtMed"] = median([a[1] for a in opData["rtTuples"]])
+                opStats[queryId][opId]["rtStd"] = std([a[1] for a in opData["rtTuples"]])
+            queryStats[queryId]["operators"] = opStats[queryId]
+        if queryStats != {}:
+            runs[run][build] = {"queryStats": queryStats, "numUsers": numUsers}
+
+    def _collectUser(self, user, dirUser, numUsers, opStats, queryStats):
+        if not os.path.isfile(os.path.join(dirUser, "queries.log")):
+            print "WARNING: no query log found in %s!" % dirUser
+            return
+        for rawline in open(os.path.join(dirUser, "queries.log")):
+            linedata = rawline.split(";")
+            if len(linedata) != 3:
+                print "invalid line in queries.log in: %s" % dirUser
+                continue
+
+            queryId     = linedata[0]
+            runtime     = float(linedata[1]) * z # convert from s to ms
+            starttime   = float(linedata[2]) * z # convert from s to ms
+
+            opStats.setdefault(queryId, {})
+            queryStats.setdefault(queryId,{
+                "totalTime": 0.0,
+                "userTime":  0.0,
+                "totalRuns": 0,
+                "totalFail": 0,
+                "rtTuples":  [],
+                "rtMin":     0.0,
+                "rtMax":     0.0,
+                "rtAvg":     0.0,
+                "rtMed":     0.0,
+                "rtStd":     0.0
+            })
+            queryStats[queryId]["totalTime"] += runtime
+            queryStats[queryId]["userTime"]  += runtime / float(numUsers)
+            queryStats[queryId]["totalRuns"] += 1
+            queryStats[queryId]["rtTuples"].append((starttime, runtime))
+
+            if len(linedata) > 3:
+                for opStr in linedata[3:]:
+                    opData = opStr.split(",")
+                    opStats[queryId].setdefault(opData[0], {
+                        "rtTuples":  [],
+                        "avgRuns":   0.0,
+                        "rtMin":     0.0,
+                        "rtMax":     0.0,
+                        "rtAvg":     0.0,
+                        "rtMed":     0.0,
+                        "rtStd":     0.0
+                    })
+                    opStats[queryId][opData[0]]["rtTuples"].append((float(opData[1]), float(opData[2])))
+

--- a/exp_mixed.py
+++ b/exp_mixed.py
@@ -83,11 +83,11 @@ kwargs = {
     "collectPerfData"   : args["perfdata"],
     "useJson"           : args["json"],
     #"dirBinary"         : "/home/Johannes.Wust/hyrise/build/",
-    "hyriseDBPath"      : "/home/Johannes.Wust/hyrise/test/",
+    #"hyriseDBPath"      : "./hyrise/test/",
     "scheduler"         : "CoreBoundQueuesScheduler",
     "serverThreads"     : 11,
     "remote"            : False,
-    "remoteUser"        : "Johannes.Wust",
+    #"remoteUser"        : "hyrise",
     #"host"              : "gaza"
 }
 

--- a/exp_skeleton.py
+++ b/exp_skeleton.py
@@ -5,7 +5,7 @@ import getpass
 
 
 aparser = argparse.ArgumentParser(description='Python skeleton benchmark implementation for HYRISE')
-aparser.add_argument('--duration', default=20, type=int, metavar='D',
+aparser.add_argument('--duration', default=10, type=int, metavar='D',
                      help='How long to run the benchmark in seconds')
 aparser.add_argument('--clients', default=-1, type=int, metavar='N',
                      help='The number of blocking clients to fork (note: this overrides --clients-min/--clients-max')
@@ -23,7 +23,7 @@ aparser.add_argument('--port', default=5001, type=int, metavar="P",
                      help='Port on which HYRISE should be run')
 aparser.add_argument('--threads', default=0, type=int, metavar="T",
                      help='Number of server threadsto use')
-aparser.add_argument('--warmup', default=5, type=int,
+aparser.add_argument('--warmup', default=3, type=int,
                      help='Warmuptime before logging is activated')
 aparser.add_argument('--manual', action='store_true',
                      help='Do not build and start a HYRISE instance (note: a HYRISE server must be running on the specified port)')

--- a/exp_skeleton.py
+++ b/exp_skeleton.py
@@ -1,0 +1,80 @@
+import argparse
+import benchmark
+import os
+import getpass
+
+
+aparser = argparse.ArgumentParser(description='Python skeleton benchmark implementation for HYRISE')
+aparser.add_argument('--duration', default=20, type=int, metavar='D',
+                     help='How long to run the benchmark in seconds')
+aparser.add_argument('--clients', default=-1, type=int, metavar='N',
+                     help='The number of blocking clients to fork (note: this overrides --clients-min/--clients-max')
+aparser.add_argument('--clients-min', default=1, type=int, metavar='N',
+                     help='The minimum number of blocking clients to fork')
+aparser.add_argument('--clients-max', default=1, type=int, metavar='N',
+                     help='The maximum number of blocking clients to fork')
+aparser.add_argument('--host', default="localhost", type=str, metavar="H",
+                     help='IP on which HYRISE should be run remotely')
+aparser.add_argument('--remoteUser', default=getpass.getuser(), type=str, metavar="R",
+                     help='remote User for remote host on which HYRISE should be run remotely')
+aparser.add_argument('--remotePath', default="/home/" + getpass.getuser() +"/benchmark", type=str,
+                     help='path of benchmark folder on remote host')
+aparser.add_argument('--port', default=5001, type=int, metavar="P",
+                     help='Port on which HYRISE should be run')
+aparser.add_argument('--threads', default=0, type=int, metavar="T",
+                     help='Number of server threadsto use')
+aparser.add_argument('--warmup', default=5, type=int,
+                     help='Warmuptime before logging is activated')
+aparser.add_argument('--manual', action='store_true',
+                     help='Do not build and start a HYRISE instance (note: a HYRISE server must be running on the specified port)')
+aparser.add_argument('--stdout', action='store_true',
+                     help='Print HYRISE server\'s stdout to console')
+aparser.add_argument('--stderr', action='store_true',
+                     help='Print HYRISE server\'s stderr to console')
+aparser.add_argument('--rebuild', action='store_true',
+                     help='Force `make clean` before each build')
+aparser.add_argument('--perfdata', default=False, action='store_true',
+                     help='Collect additional performance data. Slows down benchmark.')
+aparser.add_argument('--json', default=False, action='store_true',
+                     help='Use JSON queries instead of stored procedures.')
+args = vars(aparser.parse_args())
+
+s1 = benchmark.Settings("None", PERSISTENCY="NONE")
+
+kwargs = {
+    "remoteUser"        : args["remoteUser"],
+    "remotePath"        : args["remotePath"],
+    "remote"            : args["host"] is not "localhost",
+    "host"              : args["host"],
+    "port"              : args["port"],
+    "manual"            : args["manual"],
+    "warmuptime"        : args["warmup"],
+    "runtime"           : args["duration"],
+    "benchmarkQueries"  : [],
+    "prepareQueries"    : [],
+    "showStdout"        : args["stdout"],
+    "showStderr"        : args["stderr"],
+    "rebuild"           : args["rebuild"],
+    "serverThreads"     : args["threads"],
+    "collectPerfData"   : args["perfdata"],
+    "useJson"           : args["json"]
+}
+
+num_clients = args["clients"]
+minClients = args["clients_min"]
+maxClients = args["clients_max"]
+
+if args["clients"] > 0:
+    minClients = args["clients"]
+    maxClients = args["clients"]
+
+groupId = "skeletons"
+
+for num_clients in xrange(minClients, maxClients+1):
+    runId = "numClients_%s" % num_clients
+    kwargs["numUsers"] = num_clients
+
+    b1 = benchmark.SkeletonBenchmark(groupId, runId, s1, **kwargs)
+
+    b1.run()
+

--- a/exp_tpcch.py
+++ b/exp_tpcch.py
@@ -23,7 +23,7 @@ aparser.add_argument('--port', default=5001, type=int, metavar="P",
                      help='Port on which HYRISE should be run')
 aparser.add_argument('--threads', default=0, type=int, metavar="T",
                      help='Number of server threadsto use')
-aparser.add_argument('--warmup', default=3, type=int,
+aparser.add_argument('--warmup', default=10, type=int,
                      help='Warmuptime before logging is activated')
 aparser.add_argument('--manual', action='store_true',
                      help='Do not build and start a HYRISE instance (note: a HYRISE server must be running on the specified port)')

--- a/exp_tpcch.py
+++ b/exp_tpcch.py
@@ -74,7 +74,9 @@ for num_clients in xrange(minClients, maxClients+1):
     runId = "numClients_%s" % num_clients
     kwargs["numUsers"] = num_clients
 
-    b1 = benchmark.TPCCHBenchmark(groupId, runId, s1, **kwargs)
+    queries = {1, 3, 6, 18, 19}
+
+    b1 = benchmark.TPCCHBenchmark(queries, groupId, runId, s1, **kwargs)
 
     b1.run()
 

--- a/exp_tpcch.py
+++ b/exp_tpcch.py
@@ -1,0 +1,80 @@
+import argparse
+import benchmark
+import os
+import getpass
+
+
+aparser = argparse.ArgumentParser(description='Python skeleton benchmark implementation for HYRISE')
+aparser.add_argument('--duration', default=10, type=int, metavar='D',
+                     help='How long to run the benchmark in seconds')
+aparser.add_argument('--clients', default=-1, type=int, metavar='N',
+                     help='The number of blocking clients to fork (note: this overrides --clients-min/--clients-max')
+aparser.add_argument('--clients-min', default=1, type=int, metavar='N',
+                     help='The minimum number of blocking clients to fork')
+aparser.add_argument('--clients-max', default=1, type=int, metavar='N',
+                     help='The maximum number of blocking clients to fork')
+aparser.add_argument('--host', default="localhost", type=str, metavar="H",
+                     help='IP on which HYRISE should be run remotely')
+aparser.add_argument('--remoteUser', default=getpass.getuser(), type=str, metavar="R",
+                     help='remote User for remote host on which HYRISE should be run remotely')
+aparser.add_argument('--remotePath', default="/home/" + getpass.getuser() +"/benchmark", type=str,
+                     help='path of benchmark folder on remote host')
+aparser.add_argument('--port', default=5001, type=int, metavar="P",
+                     help='Port on which HYRISE should be run')
+aparser.add_argument('--threads', default=0, type=int, metavar="T",
+                     help='Number of server threadsto use')
+aparser.add_argument('--warmup', default=3, type=int,
+                     help='Warmuptime before logging is activated')
+aparser.add_argument('--manual', action='store_true',
+                     help='Do not build and start a HYRISE instance (note: a HYRISE server must be running on the specified port)')
+aparser.add_argument('--stdout', action='store_true',
+                     help='Print HYRISE server\'s stdout to console')
+aparser.add_argument('--stderr', action='store_true',
+                     help='Print HYRISE server\'s stderr to console')
+aparser.add_argument('--rebuild', action='store_true',
+                     help='Force `make clean` before each build')
+aparser.add_argument('--perfdata', default=False, action='store_true',
+                     help='Collect additional performance data. Slows down benchmark.')
+aparser.add_argument('--json', default=False, action='store_true',
+                     help='Use JSON queries instead of stored procedures.')
+args = vars(aparser.parse_args())
+
+s1 = benchmark.Settings("None", PERSISTENCY="NONE")
+
+kwargs = {
+    "remoteUser"        : args["remoteUser"],
+    "remotePath"        : args["remotePath"],
+    "remote"            : args["host"] is not "localhost",
+    "host"              : args["host"],
+    "port"              : args["port"],
+    "manual"            : args["manual"],
+    "warmuptime"        : args["warmup"],
+    "runtime"           : args["duration"],
+    "benchmarkQueries"  : [],
+    "prepareQueries"    : [],
+    "showStdout"        : args["stdout"],
+    "showStderr"        : args["stderr"],
+    "rebuild"           : args["rebuild"],
+    "serverThreads"     : args["threads"],
+    "collectPerfData"   : args["perfdata"],
+    "useJson"           : args["json"]
+}
+
+num_clients = args["clients"]
+minClients = args["clients_min"]
+maxClients = args["clients_max"]
+
+if args["clients"] > 0:
+    minClients = args["clients"]
+    maxClients = args["clients"]
+
+groupId = "tpcch"
+
+for num_clients in xrange(minClients, maxClients+1):
+    runId = "numClients_%s" % num_clients
+    kwargs["numUsers"] = num_clients
+
+    b1 = benchmark.TPCCHBenchmark(groupId, runId, s1, **kwargs)
+
+    b1.run()
+

--- a/exp_tpcch.py
+++ b/exp_tpcch.py
@@ -5,7 +5,7 @@ import getpass
 
 
 aparser = argparse.ArgumentParser(description='Python skeleton benchmark implementation for HYRISE')
-aparser.add_argument('--duration', default=30, type=int, metavar='D',
+aparser.add_argument('--duration', default=120, type=int, metavar='D',
                      help='How long to run the benchmark in seconds')
 aparser.add_argument('--clients', default=-1, type=int, metavar='N',
                      help='The number of blocking clients to fork (note: this overrides --clients-min/--clients-max')
@@ -76,6 +76,7 @@ for num_clients in xrange(minClients, maxClients+1):
 
     #queries = {1, 3, 6, 18, 19} # for table file fetching
     queries = {1, 6}           # for mysql tables
+    # don't forget to set the HYRISE_MYSQL_{HOST,PORT,USER,PASS} environment variables if using mysql tables
 
     b1 = benchmark.TPCCHBenchmark(queries, groupId, runId, s1, useMysqlTables=True, **kwargs)
 

--- a/exp_tpcch.py
+++ b/exp_tpcch.py
@@ -5,7 +5,7 @@ import getpass
 
 
 aparser = argparse.ArgumentParser(description='Python skeleton benchmark implementation for HYRISE')
-aparser.add_argument('--duration', default=10, type=int, metavar='D',
+aparser.add_argument('--duration', default=30, type=int, metavar='D',
                      help='How long to run the benchmark in seconds')
 aparser.add_argument('--clients', default=-1, type=int, metavar='N',
                      help='The number of blocking clients to fork (note: this overrides --clients-min/--clients-max')
@@ -74,9 +74,10 @@ for num_clients in xrange(minClients, maxClients+1):
     runId = "numClients_%s" % num_clients
     kwargs["numUsers"] = num_clients
 
-    queries = {1, 3, 6, 18, 19}
+    #queries = {1, 3, 6, 18, 19} # for table file fetching
+    queries = {1, 6}           # for mysql tables
 
-    b1 = benchmark.TPCCHBenchmark(queries, groupId, runId, s1, **kwargs)
+    b1 = benchmark.TPCCHBenchmark(queries, groupId, runId, s1, useMysqlTables=True, **kwargs)
 
     b1.run()
 

--- a/plt_skeleton.py
+++ b/plt_skeleton.py
@@ -1,0 +1,27 @@
+import argparse
+import benchmark
+
+if __name__ == "__main__":
+	aparser = argparse.ArgumentParser(description='Plotter for HYRISE Skeleton Benchmark results')
+	aparser.add_argument('groupId', type=str, metavar="GROUP",
+	                     help='Group ID for benchmark results to be plotted')
+	aparser.add_argument('--stats', action='store_true',
+	                     help='Print run statistics and exit')
+	args = vars(aparser.parse_args())
+
+	plotter = benchmark.Plotter(args["groupId"])
+
+	if args["stats"]:
+		plotter.printStatistics()
+		exit()
+
+	plotter.plotResponseTimesVaryingUsers()
+
+	plotter.plotResponseTimeFrequencies()
+
+	#plotter.plotTotalThroughput()
+
+	#plotter.plotTotalFails()
+
+	#plotter.plotTransactionResponseTimes()
+

--- a/plt_tpcch.py
+++ b/plt_tpcch.py
@@ -1,0 +1,16 @@
+import argparse
+import benchmark
+
+if __name__ == "__main__":
+    aparser = argparse.ArgumentParser(description='Plotter for HYRISE TPC-CH Benchmark results')
+    aparser.add_argument('--groupId', type=str, metavar="GROUP", default="tpcch",
+                         help='Group ID for benchmark results to be plotted')
+    args = vars(aparser.parse_args())
+
+    plotter = benchmark.TPCCHPlotter(args["groupId"])
+
+    plotter.printStatistics()
+
+
+
+


### PR DESCRIPTION
This adds a skeleton benchmark as sample basis for further benchmarks.
Adds a benchmark and statistical summary for TPC-CH queries (current 1,6), using either the hyrise csv or mysql table loader.
